### PR TITLE
Allow remove punctuation in tokenize

### DIFF
--- a/src/book.py
+++ b/src/book.py
@@ -131,7 +131,8 @@ class BookText():
         add_stopwords CURRENTLY UNWORKING (default []): list of words to be added to stopword list
         """
 
-        if include_punctuation:
+        # can't remove puncuation for sentences regardless
+        if include_punctuation or 'sent' in on.lower():
             token = self._text.lower()
         else:
             # remove punctuation

--- a/src/book.py
+++ b/src/book.py
@@ -2,6 +2,7 @@ from nltk.corpus import stopwords
 from nltk import FreqDist, word_tokenize, sent_tokenize, WordNetLemmatizer
 import re
 import random
+import string
 
 
 class BookText():
@@ -116,7 +117,7 @@ class BookText():
             return BookText(filepath=None, rawtext=cleaned, author=self.author, title=self.title, meta=self.meta)
 
     def tokenize(self, on, rem_stopwords=True, stopword_lang='english',
-                 add_stopwords=[]):
+                 add_stopwords=[], include_punctuation=False):
         """Tokenize words or sentences in the text
 
         Produces lists of either words or sentences contained in the text
@@ -129,10 +130,17 @@ class BookText():
         stopword_lang (default 'english'): language of stopword corpus to use
         add_stopwords CURRENTLY UNWORKING (default []): list of words to be added to stopword list
         """
+
+        if include_punctuation:
+            token = self._text.lower()
+        else:
+            # remove punctuation
+            token = self._text.lower().translate(
+                str.maketrans('', '', string.punctuation + '”“’'))
         if 'word' in on.lower():
-            token = word_tokenize(self._text.lower())
+            token = word_tokenize(token)
         elif 'sent' in on.lower():
-            token = sent_tokenize(self._text.lower())
+            token = sent_tokenize(token)
         else:
             raise KeyError(
                 "Arugument 'on' must refer to either word or sentence")


### PR DESCRIPTION
Add parameter `include_punctuation` in `BookText.tokenize()`. If False (which I've made default), it will remove punctuation before tokenizing words.

By extension, the `word_count` method will now exclude punctuation by default.

Fixes #11