### PR TITLE
Add additional dash type

### DIFF
--- a/src/book.py
+++ b/src/book.py
@@ -100,7 +100,7 @@ class BookText():
 
         garbage = '\ufeff|â€™|â€"|â€œ|â€˜|â€\x9d|â€œi|_|â€'
         cleaned = re.sub(garbage, '', cleaned)
-        cleaned = cleaned.replace('-', ' ')
+        cleaned = cleaned.replace('-', ' ').replace('—', ' ')
 
         if lemmatize:
             WNLemma = WordNetLemmatizer()


### PR DESCRIPTION
`—` is different from `-`, so I added it to `clean`, where it is replaced by a space