### PR TITLE
fixing meta data search and title

### DIFF
--- a/src/book.py
+++ b/src/book.py
@@ -33,10 +33,13 @@ class BookText():
         else:
             data = rawtext
         # Using regex to mark the start and end of the book
-        rex_start = r"START OF (THIS|THE) PROJECT GUTENBERG EBOOK (.*)\s*\*\*\*"
+        # The question mark lets us match the first instance of '***' only
+        rex_start = r"START OF (THIS|THE) PROJECT GUTENBERG EBOOK (.*?)\s*\*\*\*"
         rex_end = r"(?i)END of (this|the|) Project Gutenberg"
         try:
-            start_pos = re.search(rex_start, data).span()[1]
+            # the DOTALL flag allows the regex to match newline characters,
+            # which may be found if the title has a subtitle
+            start_pos = re.search(rex_start, data, flags=re.DOTALL).span()[1]
         except AttributeError:  # re.search returned None 
             start_pos = 0
         try:
@@ -83,6 +86,10 @@ class BookText():
                     self._title = None
         else:
             self._title = title
+
+        if self._title is not None:
+            # removing newlines and excessive white space in title
+            self._title = re.sub('\s+', ' ', self._title)
 
             
     def __add__(self, other): 


### PR DESCRIPTION
2 fixes:

fixes #38 
removes newline characters and excessive whitespace in titles (e.g. A Christmas Carol has a newline in the inferred title)